### PR TITLE
Update nibe.py

### DIFF
--- a/sensor/nibe.py
+++ b/sensor/nibe.py
@@ -23,14 +23,16 @@ PLATFORM_SCHEMA = vol.Schema({
     }, extra=vol.ALLOW_EXTRA)
 
 SCALE = {
-        '°C' : { 'scale' : 10,  'unit': TEMP_CELSIUS, 'icon': None },
-        'A'  : { 'scale' : 10,  'unit': 'A'         , 'icon': 'mdi:power-plug' },
-        'DM' : { 'scale' : 10,  'unit': 'DM'        , 'icon': None },
-        'kW' : { 'scale' : 100, 'unit': 'kW'        , 'icon': None },
-        'Hz' : { 'scale' : 1  , 'unit': 'Hz'        , 'icon': 'mdi:update' },
-        '%'  : { 'scale' : 10 , 'unit': '%'         , 'icon': None },
-        'h'  : { 'scale' : 10 , 'unit': 'h'         , 'icon': 'mdi:clock' },
+        '°C' 		: { 'scale' : 10,   'unit': TEMP_CELSIUS, 	'icon': None },
+        'A'  		: { 'scale' : 10,   'unit': 'A', 		'icon': 'mdi:power-plug' },
+        'DM' 		: { 'scale' : 10,   'unit': 'DM', 		'icon': None },
+        'kW' 		: { 'scale' : 100,  'unit': 'kW', 		'icon': None },
+        'Hz' 		: { 'scale' : 10,   'unit': 'Hz', 		'icon': 'mdi:update' },
+        '%' 		: { 'scale' : 1,    'unit': '%', 		'icon': None },
+        'h'		: { 'scale' : 1,    'unit': 'h',                'icon': 'mdi:clock' },
+        'öre/kWh'	: { 'scale' : 100,  'unit': 'kr/MWh',		'icon': None },
 }
+
 
 SCALE_DEFAULT = { 'scale': None, 'unit': None, 'icon': None }
 
@@ -82,10 +84,10 @@ class NibeSensor(Entity):
         """Return the state attributes."""
         return {
             'designation'  : self._data['designation'],
-            'parameter id' : self._data['parameterId'],
-            'display value': self._data['displayValue'],
-            'raw value'    : self._data['rawValue'],
-            'display unit' : self._data['unit'],
+            'parameter_id' : self._data['parameterId'],
+            'display_value': self._data['displayValue'],
+            'raw_value'    : self._data['rawValue'],
+            'display_unit' : self._data['unit'],
         }
 
     @property


### PR DESCRIPTION
device_state_attributes with underscore helps when creating template sensors in HA from sensorns starting with numbers:

"If your template uses an entity_id that begins with a number (example: states.device_tracker.2008_gmc) you must use a bracket syntax to avoid errors caused by rendering the entity_id improperly. In the example given, the correct syntax for the device tracker would be: states.device_tracker['2008_gmc']"
https://home-assistant.io/docs/configuration/templating/